### PR TITLE
Skip 3800 agent e2e tests due to intermittent failures

### DIFF
--- a/tests/agents/test_3800_agente2e.py
+++ b/tests/agents/test_3800_agente2e.py
@@ -25,6 +25,10 @@ from select_ai.agent import (
     ToolParams,
 )
 
+pytestmark = pytest.mark.skip(
+    reason="Temporarily skipped due to intermittent failures. This needs to be root caused before enabling"
+)
+
 # ----------------------------------------------------------------------
 # LOGGING
 # ----------------------------------------------------------------------

--- a/tests/agents/test_3800_async_agente2e.py
+++ b/tests/agents/test_3800_async_agente2e.py
@@ -30,6 +30,10 @@ from select_ai.agent import (
     ToolParams,
 )
 
+pytestmark = pytest.mark.skip(
+    reason="Temporarily skipped due to intermittent failures. This needs to be root caused before enabling"
+)
+
 pytestmark = pytest.mark.anyio
 
 # ----------------------------------------------------------------------

--- a/tests/agents/test_3800_async_agente2e.py
+++ b/tests/agents/test_3800_async_agente2e.py
@@ -30,11 +30,12 @@ from select_ai.agent import (
     ToolParams,
 )
 
-pytestmark = pytest.mark.skip(
-    reason="Temporarily skipped due to intermittent failures. This needs to be root caused before enabling"
-)
-
-pytestmark = pytest.mark.anyio
+pytestmark = [
+    pytest.mark.anyio,
+    pytest.mark.skip(
+        reason="Temporarily skipped due to intermittent failures. This needs to be root caused before enabling"
+    ),
+]
 
 # ----------------------------------------------------------------------
 # LOGGING


### PR DESCRIPTION
Currently, test_3800_agente2e.py and test_3800_async_agente2e.py fail intermittently due to 
```
ORA-20051: Task Order 0 failed with error: Task failed: ORA-20052: Invalid tool - None is not valid
```

This blocks merges. 

Sometimes it succeeds on retry however each run takes an hour long to finish. So, skipping these until we find the root cause. The tests should run the same everytime. 

@BhavaniKondra 
